### PR TITLE
fix : display controlPlanLine name instead of characteristic if not null

### DIFF
--- a/packages/apps/quality/src/components/atoms/ControlEntrySampleLineHeader/ControlEntrySampleLineHeader.tsx
+++ b/packages/apps/quality/src/components/atoms/ControlEntrySampleLineHeader/ControlEntrySampleLineHeader.tsx
@@ -52,7 +52,9 @@ const ControlEntrySampleLineHeader = ({}) => {
         />
       </View>
       <Text>{`${I18n.t('Quality_Characteristic')} : ${
-        sampleLine.controlPlanLine?.characteristic?.name
+        sampleLine.controlPlanLine?.name != null
+          ? sampleLine.controlPlanLine?.name
+          : sampleLine.controlPlanLine?.characteristic?.name
       }`}</Text>
     </View>
   );


### PR DESCRIPTION
RM#75237