### PR TITLE
fix: hide keyboard when click outside of inputs in KeyboardAvoidingScrollView

### DIFF
--- a/changelogs/unreleased/79225.json
+++ b/changelogs/unreleased/79225.json
@@ -1,0 +1,5 @@
+{
+  "title": "KeyboardAvoidingScrollView: hide keyboard when click outside of inputs",
+  "type": "fix",
+  "packages": "ui"
+}

--- a/packages/ui/src/components/atoms/KeyboardAvoidingScrollView/KeyboardAvoidingScrollView.tsx
+++ b/packages/ui/src/components/atoms/KeyboardAvoidingScrollView/KeyboardAvoidingScrollView.tsx
@@ -65,7 +65,7 @@ const KeyboardAvoidingScrollView = ({
       }>
       <ScrollView
         style={globalStyle}
-        keyboardShouldPersistTaps="always"
+        keyboardShouldPersistTaps="handled"
         contentContainerStyle={[
           styles.scrollContent,
           getZIndexStyles(10),


### PR DESCRIPTION
RM#79225