### PR TITLE
fix: change keyboardOffset on FormView to avoid keyboard over inputs on Android

### DIFF
--- a/changelogs/unreleased/79307.json
+++ b/changelogs/unreleased/79307.json
@@ -1,0 +1,5 @@
+{
+  "title": "FormView: avoid keyboard over inputs on Android",
+  "type": "fix",
+  "packages": "core"
+}

--- a/packages/core/src/components/pages/FormView/FormView.tsx
+++ b/packages/core/src/components/pages/FormView/FormView.tsx
@@ -336,7 +336,7 @@ const FormView = ({
       <KeyboardAvoidingScrollView
         keyboardOffset={{
           ios: 70,
-          android: 100,
+          android: 125,
         }}
         style={styles.scroll}>
         {Array.isArray(errors) && (


### PR DESCRIPTION
RM#79307