### PR TITLE
fix: prevent display of empty badge when priority doesn't exist

### DIFF
--- a/changelogs/unreleased/78935.json
+++ b/changelogs/unreleased/78935.json
@@ -1,0 +1,5 @@
+{
+  "title": "Manufacturing order: prevent display of empty badge when priority doesn't exist",
+  "type": "fix",
+  "packages": "manufacturing"
+}

--- a/packages/apps/manufacturing/src/components/organisms/ManufacturingOrderCard/ManufacturingOrderCard.tsx
+++ b/packages/apps/manufacturing/src/components/organisms/ManufacturingOrderCard/ManufacturingOrderCard.tsx
@@ -63,6 +63,13 @@ const ManufacturingOrderCard = ({
     )?.border;
   }, [Colors, status]);
 
+  const isPriorityValid = useMemo(
+    () =>
+      priority != null &&
+      Object.values(ManufacturingOrder.priority).includes(priority),
+    [priority],
+  );
+
   const [startDate, endDate] = ManufacturingOrder.getDates(
     status,
     plannedStartDate,
@@ -78,8 +85,7 @@ const ManufacturingOrderCard = ({
       style={[borderStyle, style]}
       sideBadges={{
         items: [
-          {
-            showIf: priority != null,
+          isPriorityValid && {
             color: ManufacturingOrder.getPriorityColor(priority, Colors),
             displayText: ManufacturingOrder.getPriority(priority, I18n),
           },

--- a/packages/apps/manufacturing/src/components/organisms/ManufacturingOrderHeader/ManufacturingOrderHeader.tsx
+++ b/packages/apps/manufacturing/src/components/organisms/ManufacturingOrderHeader/ManufacturingOrderHeader.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import React, {useMemo} from 'react';
 import {StyleSheet, View} from 'react-native';
 import {Badge, LabelText, Text, useThemeColor} from '@axelor/aos-mobile-ui';
 import {useTranslator} from '@axelor/aos-mobile-core';
@@ -38,6 +38,13 @@ const ManufacturingOrderHeader = ({
   const Colors = useThemeColor();
   const I18n = useTranslator();
 
+  const isPriorityValid = useMemo(
+    () =>
+      priority != null &&
+      Object.values(ManufacturingOrder.priority).includes(priority),
+    [priority],
+  );
+
   return (
     <View style={styles.infoContainer}>
       <View style={styles.refContainer}>
@@ -57,13 +64,13 @@ const ManufacturingOrderHeader = ({
             title={ManufacturingOrder.getStatus(status, I18n)}
           />
         )}
-        {priority == null ? (
-          <View style={styles.refContainer} />
-        ) : (
+        {isPriorityValid ? (
           <Badge
             color={ManufacturingOrder.getPriorityColor(priority, Colors)}
             title={ManufacturingOrder.getPriority(priority, I18n)}
           />
+        ) : (
+          <View style={styles.refContainer} />
         )}
       </View>
     </View>


### PR DESCRIPTION
RM#78935