### PR TITLE
fix: value of LabelText can't be on multiple lines in some containers

### DIFF
--- a/changelogs/unreleased/80853.json
+++ b/changelogs/unreleased/80853.json
@@ -1,0 +1,5 @@
+{
+  "title": "LabelText: allow value field to be on multiple lines in all containers",
+  "type": "fix",
+  "packages": "ui"
+}

--- a/packages/ui/src/components/molecules/LabelText/LabelText.tsx
+++ b/packages/ui/src/components/molecules/LabelText/LabelText.tsx
@@ -83,6 +83,7 @@ const styles = StyleSheet.create({
     marginRight: 5,
   },
   txtDetails: {
+    flex: 1,
     fontWeight: 'bold',
   },
   icon: {


### PR DESCRIPTION
RM#80853