### PR TITLE
fix: manage margin bottom on AutoCompleteSearch when list is empty

### DIFF
--- a/changelogs/unreleased/87262.json
+++ b/changelogs/unreleased/87262.json
@@ -1,0 +1,5 @@
+{
+  "title": "AutoCompleteSearch: manage margin bottom when the list is empty",
+  "type": "fix",
+  "packages": "ui"
+}

--- a/packages/ui/src/components/organisms/AutoCompleteSearch/AutoCompleteSearch.tsx
+++ b/packages/ui/src/components/organisms/AutoCompleteSearch/AutoCompleteSearch.tsx
@@ -260,9 +260,10 @@ const AutoCompleteSearch = ({
 
   const marginBottom = useMemo(() => {
     if (isScrollViewContainer && displayList) {
-      const visibleListLength = !Array.isArray(objectList)
-        ? 0
-        : Math.min(objectList.length, 5);
+      const visibleListLength = Math.max(
+        !Array.isArray(objectList) ? 0 : Math.min(objectList.length, 5),
+        1,
+      );
 
       return visibleListLength * ITEM_HEIGHT + 5;
     }


### PR DESCRIPTION
RM#87262