### PR TITLE
Fix: POST to //callback during log-in.

### DIFF
--- a/packages/core/src/api/login-api.ts
+++ b/packages/core/src/api/login-api.ts
@@ -75,8 +75,10 @@ export async function loginApi(
   requestInterceptorId: number;
   responseInterceptorId: number;
 }> {
+  const normalizedUrl = url.endsWith('/') ? url.slice(0, -1) : url;
+  const normalizedLoginPath = loginPath.startsWith('/') ? loginPath : `/${loginPath}`;
   return axios
-    .post(`${url}${loginPath}`, {username, password})
+    .post(`${normalizedUrl}${normalizedLoginPath}`, {username, password})
     .then(res => initAxiosWithHeaders(res, url));
 }
 


### PR DESCRIPTION
When I was trying to log in using the mobile app, it was trying to POST to `//callback`, which failed and resulted in a `400` status code. I believe this may have something to do with the fact that I serve AOS from the root of my domain, and that it may be an issue for others. This commit ensures that the POST URI is correctly formatted.