### PR TITLE
fix: address is not automatically filled when clicking on map widget

### DIFF
--- a/changelogs/unreleased/94928.json
+++ b/changelogs/unreleased/94928.json
@@ -1,0 +1,5 @@
+{
+  "title": "Map widget: automatically filled address when clicking on widget",
+  "type": "fix",
+  "packages": "core"
+}

--- a/packages/core/src/tools/linking.helper.ts
+++ b/packages/core/src/tools/linking.helper.ts
@@ -67,7 +67,6 @@ export const iosMapURLBuilder = (
 ) => {
   const params = [
     {param: 'q', value: address},
-    {param: 'saddr', value: address},
     {param: 'daddr', value: destination},
     {param: 'sll', value: `${latitude},${longitude}`},
     {param: 'dirflg', value: transportType},


### PR DESCRIPTION
RM#94928