### PR TITLE
fix: make props optional on DoubleSearchScannerSearchBar

### DIFF
--- a/changelogs/unreleased/99374.json
+++ b/changelogs/unreleased/99374.json
@@ -1,0 +1,5 @@
+{
+  "title": "DoubleScannerSearchBar: make props sliceFunctionBarCodeData and onFetchDataAction optional",
+  "type": "fix",
+  "packages": "core"
+}

--- a/packages/core/src/components/templates/DoubleScannerSearchBar/DoubleScannerSearchBar.tsx
+++ b/packages/core/src/components/templates/DoubleScannerSearchBar/DoubleScannerSearchBar.tsx
@@ -51,8 +51,8 @@ interface DoubleScannerSearchBarProps {
   isListEnd?: boolean;
   isScrollViewContainer?: boolean;
   sliceBarCodeFunction: any;
-  sliceFunctionBarCodeData: Object;
-  onFetchDataAction: any;
+  sliceFunctionBarCodeData?: Object;
+  onFetchDataAction?: any;
   displayBarCodeInput?: boolean;
 }
 


### PR DESCRIPTION
RM#99374